### PR TITLE
ACTUALIZACIONES - JUL-19-25

### DIFF
--- a/src/components/DesarrolloProfesionalItem.tsx
+++ b/src/components/DesarrolloProfesionalItem.tsx
@@ -101,10 +101,10 @@ export default function DesarrolloProfesionalItem({
 
           {/* Stats */}
           <div className="flex items-center justify-between text-xs text-gray-500 mb-4">
-            <div className="flex items-center gap-1">
+            {/* <div className="flex items-center gap-1">
               <IconClock className="w-3 h-3" />
               <span>{formacionInfo.duration}</span>
-            </div>
+            </div> */}
             <div className="flex items-center gap-1">
               <IconUsers className="w-3 h-3" />
               <span>{formacionInfo.participants}</span>

--- a/src/components/FormacionDetail.tsx
+++ b/src/components/FormacionDetail.tsx
@@ -117,14 +117,15 @@ export default function FormacionDetail({ formacion }: Props) {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                {formacion.url}
+                {/* {formacion.url} */}
+                VER MÁS INFORMACIÓN
               </Link>
             </div>
           </div>
         )}
 
         {/* Información secundaria (ID, Created_at) */}
-        <div className="p-6 pt-0 text-xs text-gray-500 space-x-4">
+        {/* <div className="p-6 pt-0 text-xs text-gray-500 space-x-4">
           <span>ID: {formacion.id}</span>
           <span>
             Creado:{" "}
@@ -132,11 +133,11 @@ export default function FormacionDetail({ formacion }: Props) {
               ? dateToFormat(new Date(formacion.created_at))
               : "N/D"}
           </span>
-        </div>
+        </div> */}
       </main>
 
       {/* Pie de página */}
-      <footer className="flex-initial">
+      {/* <footer className="flex-initial">
         {formacion.url && (
           <div className="bg-gray-100 p-4 flex justify-end">
             <Link
@@ -149,7 +150,7 @@ export default function FormacionDetail({ formacion }: Props) {
             </Link>
           </div>
         )}
-      </footer>
+      </footer> */}
     </div>
   );
 }

--- a/src/components/TitleFormacionContinua.tsx
+++ b/src/components/TitleFormacionContinua.tsx
@@ -57,15 +57,15 @@ export default function TitleFormacionContinua() {
         <div className="flex flex-wrap justify-center gap-8 mt-12">
           <div className="text-center">
             <div className="text-3xl font-bold text-custom-green mb-2">+50</div>
-            <div className="text-sm text-gray-600 uppercase tracking-wide">Programas Disponibles</div>
+            <div className="text-sm text-gray-600 uppercase tracking-wide">Programas<br></br>Disponibles</div>
           </div>
           <div className="text-center">
             <div className="text-3xl font-bold text-custom-green mb-2">100%</div>
-            <div className="text-sm text-gray-600 uppercase tracking-wide">Online</div>
+            <div className="text-sm text-gray-600 uppercase tracking-wide">Entrenamiento<br></br>Online</div>
           </div>
           <div className="text-center">
             <div className="text-3xl font-bold text-custom-green mb-2">24/7</div>
-            <div className="text-sm text-gray-600 uppercase tracking-wide">Acceso</div>
+            <div className="text-sm text-gray-600 uppercase tracking-wide">Acceso<br></br>Continuo</div>
           </div>
         </div>
       </div>

--- a/src/pages/formaciones.tsx
+++ b/src/pages/formaciones.tsx
@@ -54,6 +54,7 @@ export default function FormacionesMaintenance() {
         toast.success("Formación guardada correctamente");
         refresh();
       } else {
+        console.log(res);
         toast.error(`Error al guardar la formación: ${res.message}`);
       }
     } catch (error) {


### PR DESCRIPTION
Solicitudes del cliente

Se publicaron 8 nuevos cursos y se eliminaron la mayoría de los anteriores.

ELEMENTOS A MODIFICAR EN ALUMNI UPNFM:
Quitar el dato de fecha en las pestañas de formación de DIPLOMADOS, CERTIFICADOS, POSTGRADOS. En la pestaña de formación de CURSOS, elimina los cursos de: Género e inclusión social, Toma de decisiones y solución de conflictos, Orientación Vocacional, Habilidades blandas, Aprendizaje Socioemocional, Ciberciudadanía - Conociendo la Ciudadanía Digital, Orientación sociolaboral. Que pertenecían al programa de USAID. En la pestaña de formación POSTGRADOS: eliminar el dato de la fecha, que permanezca el dato de tiempo de aplicación, que aparece como un icono de reloj, en algunos sale N/D, eso significa que no este definido en la beca, en las demás si están las fechas correctas, eliminar la BECA DE FUNIBER, el enlace esta malo.